### PR TITLE
Incremental base64 encoding to avoid stack overflows

### DIFF
--- a/Network/Mail/Mime.hs
+++ b/Network/Mail/Mime.hs
@@ -29,7 +29,7 @@ import Control.Arrow
 import System.Process
 import System.IO
 import System.Exit
-import Codec.Binary.Base64 (encode)
+import qualified Codec.Binary.Base64 as Base64
 import Control.Monad ((<=<), forM)
 import Data.List (intersperse)
 import qualified Data.Text.Lazy as LT
@@ -120,8 +120,7 @@ partToPair (Part contentType encoding disposition headers content) =
     builder =
         case encoding of
             None -> fromWriteList writeByteString $ L.toChunks content
-            Base64 -> fromWriteList writeWord8 $ map (toEnum . fromEnum)
-                    $ encode $ L.unpack content
+            Base64 -> base64 content
             QuotedPrintableText -> quotedPrintable True content
             QuotedPrintableBinary -> quotedPrintable False content
 
@@ -306,3 +305,15 @@ encodedWord t = mconcat
         | otherwise = go'' w
     go'' w = fromWord8 61 `mappend` hex (w `shiftR` 4)
                           `mappend` hex (w .&. 15)
+
+-- Encode data into base64. Base64.encode cannot be used here
+-- because it suffers from stack overflow when used with larget input.
+base64 :: L.ByteString -> Builder
+base64 = go Base64.encodeInc . groupN 10 . L.unpack
+    where
+        go encoder [] = case encoder Base64.EDone of
+            Base64.EFinal str -> fromChar8String str
+        go encoder (chunk:rest) = case encoder $ Base64.EChunk chunk of
+            Base64.EPart str next -> fromChar8String str `mappend` go next rest
+        fromChar8String = fromWriteList writeWord8 . map (toEnum . fromEnum)
+        groupN n = map (take n) . takeWhile (not . null) . iterate (drop n)


### PR DESCRIPTION
I experienced stack overflow errors when using mime-mail to send an email with large (~1MB) files attached. I found that it happens inside Codec.Binary.Base64.encode function from the dataenc-0.14 package and that the earlier versions do not suffer from the problem.

However, the author of dataenc told me that the nonlinear stack usage is by design, and recommend me to use the encodeInc function. So here is a patch to move to using encodeInc.
