### PR TITLE
Support process-1.1.x (needed to be compatible with haskell98 that comes with ghc-7.2.1)

### DIFF
--- a/mime-mail/mime-mail.cabal
+++ b/mime-mail/mime-mail.cabal
@@ -18,7 +18,7 @@ Library
   Exposed-modules: Network.Mail.Mime
   Build-depends:   base                >= 4          && < 5
                  , dataenc             >= 0.14       && < 0.15
-                 , process             >= 1.0        && < 1.1
+                 , process             >= 1.0        && < 1.2
                  , random              >= 1.0        && < 1.1
                  , blaze-builder       >= 0.2.1      && < 0.4
                  , bytestring          >= 0.9.1      && < 0.10


### PR DESCRIPTION
This change allows mime-mail to use process-1.1.x (required for ghc-7.2.1 compatibility).
