### PR TITLE
Attachments

### DIFF
--- a/mime-mail/mime-mail.cabal
+++ b/mime-mail/mime-mail.cabal
@@ -18,11 +18,13 @@ Library
   Exposed-modules: Network.Mail.Mime
   Build-depends:   base                >= 4          && < 5
                  , dataenc             >= 0.14       && < 0.15
+                 , base64-bytestring   >= 0.1        && < 1.0
                  , process             >= 1.0        && < 1.2
                  , random              >= 1.0        && < 1.1
                  , blaze-builder       >= 0.2.1      && < 0.4
                  , bytestring          >= 0.9.1      && < 0.10
                  , text                >= 0.7        && < 0.12
+                 , filepath            >= 1.2        && < 1.3
 
 source-repository head
   type:     git


### PR DESCRIPTION
Hi Snoyberg,

I made two small change to your library: please look at them and decide if you want to keep these changes.
1. In your version, attaching a file give the full path as the attached filename. I used takeFileName to drop the path.
2. I used Data.ByteString.Base64 instead of Codec.Binary.Base64. This should improve performance and - more important - split the resulting string as required by email specification.

Cheers,
EffeErre
