### PR TITLE
trivial change to give the user the choice of the sendmail binary and command line options

### DIFF
--- a/mime-mail/mime-mail.cabal
+++ b/mime-mail/mime-mail.cabal
@@ -1,5 +1,5 @@
 Name:                mime-mail
-Version:             0.4.0.1
+Version:             0.4.1.0
 Synopsis:            Compose MIME email messages.
 Description:         This package provides some high-level datatypes for declaring MIME email messages, functions for automatically composing these into bytestrings, and the ability to send bytestrings via the sendmail executable. You can also use any other library you wish to send via different methods, eg directly to SMTP.
 Homepage:            http://github.com/snoyberg/mime-mail


### PR DESCRIPTION
Hi Michael,

please find a trivial change in your nice email library to allow the user to choose its sendmail binary and command-line options. I've also updated the version number, but you might want to change it to better follow your practices.
