### PR TITLE
add convenience functions

### DIFF
--- a/mime-mail/Network/Mail/Mime.hs
+++ b/mime-mail/Network/Mail/Mime.hs
@@ -277,7 +277,7 @@ sendmailCustom :: FilePath        -- ^ sendmail executable path
                   -> L.ByteString -- ^ mail message as lazy bytestring
                   -> IO ()
 sendmailCustom sm opts lbs = do
-    (Just hin, _, _, phandle) <- createProcess $ 
+    (Just hin, _, _, phandle) <- createProcess $
                                  (proc sm opts) { std_in = CreatePipe }
     L.hPut hin lbs
     hClose hin


### PR DESCRIPTION
see issue #18.

the names are up to debate. i am not very happy about `addPart` and `simpleMail`.

there is a spurious import `Blaze.ByteString.Builder.Internal.Write (fromWriteList)`. a second (not related) commit removes it. there is also a trailing whitespace fix.
