### PR TITLE
Correctly order arguments of `mailFromToSubject`

### DIFF
--- a/mime-mail/Network/Mail/Mime.hs
+++ b/mime-mail/Network/Mail/Mime.hs
@@ -318,7 +318,7 @@ simpleMail' to from subject body = addPart [plainPart body]
                                  $ mailFromToSubject from to subject
 
 mailFromToSubject :: Address -> Address -> Text -> Mail
-mailFromToSubject to from subject =
+mailFromToSubject from to subject =
     (emptyMail from) { mailTo = [to]
                      , mailHeaders = [("Subject", subject)]
                      }


### PR DESCRIPTION
Based on its name and how it is used in both simpleMail functions `mailFromToSubject` appears to be taking arguments in the incorrect order. This causes the mail to be delivered to the from address when using a simpleMail helper. I have just flipped the arguments and everything is back in order.
