### PR TITLE
Update travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: haskell
 
 install:
-    - cabal install mega-sdist hspec doctest cabal-meta cabal-src
+    - cabal install hspec doctest cabal-meta cabal-src
     - cabal-meta install --force-reinstalls
 
 script: mega-sdist --test


### PR DESCRIPTION
`cabal update` is already run before each build, so doing it a second
time manually will unnecessarily delay things.
