### PR TITLE
Add missing documentation

### DIFF
--- a/mime-mail/Network/Mail/Mime.hs
+++ b/mime-mail/Network/Mail/Mime.hs
@@ -330,7 +330,10 @@ simpleMail' :: Address -- ^ to
 simpleMail' to from subject body = addPart [plainPart body]
                                  $ mailFromToSubject from to subject
 
-mailFromToSubject :: Address -> Address -> Text -> Mail
+mailFromToSubject :: Address -- ^ from
+                  -> Address -- ^ to
+                  -> Text -- ^ subject
+                  -> Mail
 mailFromToSubject from to subject =
     (emptyMail from) { mailTo = [to]
                      , mailHeaders = [("Subject", subject)]


### PR DESCRIPTION
When working with mime-mail I always have to lookup the correct argument order in the sourcecode for some functions. I think they should be documented via haddock where applicable.

This pull request adds documentation for `simpleMail'` and `mailFromToSubject` (even if the latter already contains the information in the name I think it should always be listed in the docs).
