### PR TITLE
Add a soft line break when hitting a QPEscape at the end of an encoded line.

### DIFF
--- a/mime-mail/Network/Mail/Mime.hs
+++ b/mime-mail/Network/Mail/Mime.hs
@@ -444,7 +444,7 @@ buildQPs =
                         | S.null y = qps
                         | otherwise = QPEscape y : qps
                  in if toTake == 0
-                        then copyByteString "\r\n" `mappend` go 0 (qp:qps)
+                        then copyByteString "=\r\n" `mappend` go 0 (qp:qps)
                         else helper (S.length x * 3) (escape x) (S.null y) rest
       where
         escape =


### PR DESCRIPTION
I was running into a situation where unwanted whitespace appeared in the received e-mails in the middle of names containing multi-byte characters that need escaping. This seems to be due to not using a soft line break when hitting a `QPEscape` at the end of an encoded line. An example in a `cabal repl` session:

```
:set -XOverloadedStrings
import Network.Mail.Mime
import qualified Blaze.ByteString.Builder as B
import Data.Text.Lazy.Encoding (encodeUtf8)

B.toLazyByteString $ quotedPrintable True $ encodeUtf8 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaøaaa"
"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\r\n=C3=B8aaa"
```

With the patch this looks as follows and renders properly in the e-mail (i.e. without whitespace):

```
B.toLazyByteString $ quotedPrintable True $ encodeUtf8 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaøaaa"
"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=\r\n=C3=B8aaa"
```

I'm not entirely sure whether I fixed it in the right place or whether this might cause other issues. The existing tests still seem to be happy.
