### PR TITLE
Change license from MIT to BSD3 in haskell-mime-mail-ses.

### DIFF
--- a/mime-mail-ses/mime-mail-ses.cabal
+++ b/mime-mail-ses/mime-mail-ses.cabal
@@ -2,7 +2,7 @@ Name:                mime-mail-ses
 Version:             0.3.2
 Synopsis:            Send mime-mail messages via Amazon SES
 Homepage:            http://github.com/snoyberg/mime-mail
-License:             MIT
+License:             BSD3
 License-file:        LICENSE
 Author:              Michael Snoyman
 Maintainer:          michael@snoyman.com


### PR DESCRIPTION
In the process of packing mime-mail-ses for Debian, it was noticed that the license might not be correct in the cabal file. I've modified it to use the BSD3, as does mime-mail.

I'll be happy to change up the licensing if there are issues.
