### PR TITLE
fix: addParts: append mail parts to a Mail

### DIFF
--- a/mime-mail/Network/Mail/Mime.hs
+++ b/mime-mail/Network/Mail/Mime.hs
@@ -405,7 +405,7 @@ mailFromToSubject from to subject =
 -- To e.g. add a plain text body use
 -- > addPart [plainPart body] (emptyMail from)
 addPart :: Alternatives -> Mail -> Mail
-addPart alt mail = mail { mailParts = alt : mailParts mail }
+addPart alt mail = mail { mailParts = mailParts mail ++ [alt] }
 
 -- | Construct a UTF-8-encoded plain-text 'Part'.
 plainPart :: LT.Text -> Part


### PR DESCRIPTION
Hi !

I have noticed that ```simpleMail```, in ```Network.Mail.Mime``` includes attachments /before/ the text body in a multipart message, which looks unusual. 

This pull request modifies ```addPart```, so that attachments are appended to the mail, instead of being prepended.

BTW, thank you for this nice library ! :)

best regards,
Damien
