### PR TITLE
Fix #50: space between name and address

### DIFF
--- a/mime-mail/Network/Mail/Mime.hs
+++ b/mime-mail/Network/Mail/Mime.hs
@@ -257,7 +257,7 @@ showAddressHeader (k, as) =
 -- Since 0.4.3
 showAddress :: Address -> Builder
 showAddress a = mconcat
-    [ maybe mempty ((fromByteString " " <>) . encodedWord) (addressName a)
+    [ maybe mempty ((<> fromByteString " ") . encodedWord) (addressName a)
     , fromByteString "<"
     , fromText (sanitizeHeader $ addressEmail a)
     , fromByteString ">"

--- a/mime-mail/test/Network/Mail/MimeSpec.hs
+++ b/mime-mail/test/Network/Mail/MimeSpec.hs
@@ -56,6 +56,11 @@ spec = describe "Network.Mail.Mime" $ do
                     then True
                     else error $ show $ lines' gen
 
+        it "issue #50" $
+            let addr = Address (Just "Name_ (is): @hi?") "user@domain.tld"
+                enc = "=?utf-8?Q?Name=5F_=28is=29=3A_=40hi=3F?= <user@domain.tld>"
+             in renderAddress addr `shouldBe` enc
+
 lines' :: L8.ByteString -> [L8.ByteString]
 lines' =
     map stripCR . L8.lines


### PR DESCRIPTION
Though some MTAs seem to accept this (including some versions of postfix), RFC2822 has CWFS before '<'. Also add a test case for `renderAddress`.