### PR TITLE
Use MonadRandom to simplify renderMail.

### DIFF
--- a/mime-mail/Network/Mail/Mime.hs
+++ b/mime-mail/Network/Mail/Mime.hs
@@ -267,7 +267,7 @@ renderMailM (Mail from to cc bcc headers parts) = do
 
     pairs1 <- mapM (mapM flattenCompoundPair) pairs
     pairs' <- mapM (showPairs "alternative") pairs1
-    Pair (finalHeaders, finalBuilder) <- showPairs "mixed" pairs'
+    ~(Pair (finalHeaders, finalBuilder)) <- showPairs "mixed" pairs'
 
     let
       builder = mconcat

--- a/mime-mail/mime-mail.cabal
+++ b/mime-mail/mime-mail.cabal
@@ -26,6 +26,7 @@ Library
                  , bytestring          >= 0.9.1
                  , text                >= 0.7
                  , filepath            >= 1.2
+                 , MonadRandom         >= 0.5
 
 test-suite tests
     type: exitcode-stdio-1.0


### PR DESCRIPTION
I suggest the use of `MonadRandom` to simplify the implementation of `renderMail` and other functions using `RandomGen`.