### PR TITLE
Fix Content-Disposition header in case of filenames with unicode characters or spaces

### DIFF
--- a/mime-mail/Network/Mail/Mime.hs
+++ b/mime-mail/Network/Mail/Mime.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE CPP, DeriveGeneric, OverloadedStrings, RecordWildCards #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
 module Network.Mail.Mime
     ( -- * Datatypes
       Boundary (..)
@@ -45,33 +48,35 @@ module Network.Mail.Mime
     , mkImageParts
     ) where
 
-import qualified Data.ByteString.Lazy as L
-import Blaze.ByteString.Builder.Char.Utf8
-import Blaze.ByteString.Builder
-import Control.Concurrent (forkIO, putMVar, takeMVar, newEmptyMVar)
-import Data.Monoid
-import System.Random
-import Control.Arrow
-import System.Process
-import System.IO
-import System.Exit
-import System.FilePath (takeFileName)
-import qualified Data.ByteString.Base64 as Base64
-import Control.Monad ((<=<), (>=>), foldM, void)
-import Control.Exception (throwIO, ErrorCall (ErrorCall))
-import Data.List (intersperse)
-import qualified Data.Text.Lazy as LT
-import qualified Data.Text.Lazy.Encoding as LT
-import Data.ByteString.Char8 ()
-import Data.Bits ((.&.), shiftR)
-import Data.Char (isAscii, isControl)
-import Data.Word (Word8)
-import Data.String (IsString(..))
-import qualified Data.ByteString as S
-import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
-import GHC.Generics (Generic)
+import           Blaze.ByteString.Builder
+import           Blaze.ByteString.Builder.Char.Utf8
+import           Control.Arrow
+import           Control.Concurrent                 (forkIO, newEmptyMVar,
+                                                     putMVar, takeMVar)
+import           Control.Exception                  (ErrorCall (ErrorCall),
+                                                     throwIO)
+import           Control.Monad                      (foldM, void, (<=<), (>=>))
+import           Data.Bits                          (shiftR, (.&.))
+import qualified Data.ByteString                    as S
+import qualified Data.ByteString.Base64             as Base64
+import           Data.ByteString.Char8              ()
+import qualified Data.ByteString.Lazy               as L
+import           Data.Char                          (isAscii, isControl)
+import           Data.List                          (intersperse)
+import           Data.Monoid
+import           Data.String                        (IsString (..))
+import           Data.Text                          (Text)
+import qualified Data.Text                          as T
+import qualified Data.Text.Encoding                 as TE
+import qualified Data.Text.Lazy                     as LT
+import qualified Data.Text.Lazy.Encoding            as LT
+import           Data.Word                          (Word8)
+import           GHC.Generics                       (Generic)
+import           System.Exit
+import           System.FilePath                    (takeFileName)
+import           System.IO
+import           System.Process
+import           System.Random
 
 -- | Generates a random sequence of alphanumerics of the given length.
 randomString :: RandomGen d => Int -> d -> (String, d)
@@ -97,10 +102,10 @@ instance Random Boundary where
 
 -- | An entire mail message.
 data Mail = Mail
-    { mailFrom :: Address
-    , mailTo   :: [Address]
-    , mailCc   :: [Address]
-    , mailBcc  :: [Address]
+    { mailFrom    :: Address
+    , mailTo      :: [Address]
+    , mailCc      :: [Address]
+    , mailBcc     :: [Address]
     -- | Other headers, excluding from, to, cc and bcc.
     , mailHeaders :: Headers
     -- | A list of different sets of alternatives. As a concrete example:
@@ -109,7 +114,7 @@ data Mail = Mail
     --
     -- Make sure when specifying alternatives to place the most preferred
     -- version last.
-    , mailParts :: [Alternatives]
+    , mailParts   :: [Alternatives]
     }
   deriving (Show, Generic)
 
@@ -144,13 +149,13 @@ type Alternatives = [Part]
 
 -- | A single part of a multipart message.
 data Part = Part
-    { partType :: Text -- ^ content type
-    , partEncoding :: Encoding
+    { partType        :: Text -- ^ content type
+    , partEncoding    :: Encoding
     -- | The filename for this part, if it is to be sent with an attachemnt
     -- disposition.
     , partDisposition :: Disposition
-    , partHeaders :: Headers
-    , partContent :: PartContent
+    , partHeaders     :: Headers
+    , partContent     :: PartContent
     }
   deriving (Eq, Show, Generic)
 
@@ -316,9 +321,9 @@ showHeader (Header (k, v)) = mconcat
 showHeader (ContentDispositionHeader (cd, fn)) = mconcat
     [ fromByteString "Content-Disposition: "
     , fromByteString cd
-    , fromByteString "; filename=\""
+    , fromByteString "; filename="
     , encodeIfNeeded fn
-    , fromByteString "\"\n"
+    , fromByteString "\n"
     ]
 
 showAddressHeader :: (S.ByteString, [Address]) -> Builder
@@ -494,8 +499,8 @@ simpleMailInMemory to from subject plainBody htmlBody attachments =
 
 data InlineImage = InlineImage {
       imageContentType :: Text
-    , imageContent :: ImageContent
-    , imageCID :: Text
+    , imageContent     :: ImageContent
+    , imageCID         :: Text
     } deriving Show
 
 data ImageContent = ImageFilePath FilePath | ImageByteString L.ByteString
@@ -587,7 +592,7 @@ addAttachments xs mail = foldM fun mail xs
 addImage :: InlineImage -> IO Part
 addImage InlineImage{..} = do
     content <- case imageContent of
-                ImageFilePath fn -> L.readFile fn
+                ImageFilePath fn   -> L.readFile fn
                 ImageByteString bs -> return bs
     return
       $ Part imageContentType Base64 (InlineDisposition imageCID) [] (PartContent content)


### PR DESCRIPTION
Fixes https://github.com/snoyberg/mime-mail/issues/54

The implementation is not the most elegant but should be quite easy to understand. Feel free to suggest improvements.

Edit: After recent changes no longer related to #54 but exclusively about Unicode filenames.